### PR TITLE
For registrations, try four cardinal rotations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /opt && \
     cd /opt && \
     git clone https://github.com/girder/large_image && \
     cd large_image && \
-    # git checkout multi-single-band && \
+    # git checkout zarr-channel-axis && \
     pip install .[all] -r requirements-dev.txt --find-links https://girder.github.io/large_image_wheels
 
 COPY . /opt/main

--- a/histomicstk_extras/RegisterImages/RegisterImages.xml
+++ b/histomicstk_extras/RegisterImages/RegisterImages.xml
@@ -72,7 +72,7 @@
       <longflag>disk</longflag>
       <description>Size of disk to open thresholded images</description>
       <label>Open Disk Size</label>
-      <default>1</default>
+      <default>4</default>
       <constraints>
         <minimum>0</minimum>
         <maximum>1.e3</maximum>
@@ -110,6 +110,13 @@
       <longflag>outputMergeImage</longflag>
       <label>Output Merged Image</label>
       <description>A merged image with the transformed second image and the untransformed first image</description>
+      <channel>output</channel>
+    </image>
+    <image fileExtensions=".tiff">
+      <name>outputDebugImage</name>
+      <longflag>outputDebugImage</longflag>
+      <label>Output Debug Image</label>
+      <description>A image with all of the processing steps as frames</description>
       <channel>output</channel>
     </image>
   </parameters>


### PR DESCRIPTION
This adds features:

- Matching is done at each of the four cardinal rotations (unless point annotations are used).  The rotation with the most overlap of the two annotations/thresholds is selected.
- An optional debug image is written.  This contains a bunch of lower resolution images to help show what is going on.  More debug output is printed during the algorithm run, too.